### PR TITLE
V2.2

### DIFF
--- a/Examples/DynamicScaler/Meta.ini
+++ b/Examples/DynamicScaler/Meta.ini
@@ -43,21 +43,21 @@ Group=Testing
 
 [Author]
 Name=Proddy
-Website=https://github.com/Hampo/LuaP3DEditor
-Notes=P3D Class System - P3D Functions
-Group=LuaP3DEditor
+Website=https://github.com/Hampo/LuaP3DLib
+Notes=P3D Class System
+Group=LuaP3DLib
 
 [Author]
 Name=EnAppelsin
 Website=https://github.com/EnAppelsin
-Notes=P3D Lua idea - P3D Functions
-Group=LuaP3DEditor
+Notes=Original P3D Lua idea
+Group=LuaP3DLib
 
 [Author]
 Name=Lucas Cardellini
 Website=https://lucasstuff.com/
-Notes=P3D Functions Performance Improvements
-Group=LuaP3DEditor
+Notes=P3D Chunk Structures
+Group=LuaP3DLib
 
 [Setting]
 Type=TickBox

--- a/lib/P3D2.lua
+++ b/lib/P3D2.lua
@@ -6,7 +6,7 @@ CREDITS:
 ]]
 
 P3D = {}
-P3D.Version = "2.1"
+P3D.Version = "2.2"
 P3D.Identifiers = {
 	Anim = 0x3F0000C,
 	Animated_Object = 0x20001,

--- a/lib/P3D2.lua
+++ b/lib/P3D2.lua
@@ -223,17 +223,17 @@ local string_unpack = string.unpack
 
 local table_concat = table.concat
 local table_move = table.move
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 function P3D.MakeP3DString(str)
 	if str == nil then return nil end
 	local diff = #str & 3
 	if diff ~= 0 then
-		str = str .. string_rep("\0", 4 - diff)
+		return str .. string_rep("\0", 4 - diff)
 	end
 	return str
 end

--- a/lib/P3D2.lua
+++ b/lib/P3D2.lua
@@ -711,7 +711,7 @@ end
 
 local function AddChunk(self, Chunk, Index)
 	assert(type(Chunk) == "table" and Chunk.Identifier, "Arg #1 (Chunk) must be a valid chunk")
-	assert(Index == nil or (type(Index) == "number" and Index <= #self.Chunks), "Arg #2 (Index) must be a number smaller than the chunk count")
+	assert(Index == nil or (type(Index) == "number" and Index <= #self.Chunks + 1), "Arg #2 (Index) must be a number smaller than the chunk count")
 	
 	if Index then
 		table.insert(self.Chunks, Index, Chunk)

--- a/lib/P3D2.lua
+++ b/lib/P3D2.lua
@@ -705,7 +705,7 @@ local function Clone(self, seen)
 		res[Clone(k, s)] = Clone(v, s)
 	end
 	
-	return setmetatable(res, Clone(getmetatable(self), s)) --Should definitely clone the metatable
+	return setmetatable(res, Clone(getmetatable(self), s))
 end
 
 P3D.P3DFile = setmetatable({load = LoadP3DFile, new = LoadP3DFile, AddChunk = AddChunk, SetChunk = SetChunk, RemoveChunk = RemoveChunk, GetChunks = GetChunks, GetChunk = GetChunk, GetChunksIndexed = GetChunksIndexed, GetChunkIndexed = GetChunkIndexed, Clone = Clone}, {__call = LoadP3DFile})

--- a/lib/P3D2.lua
+++ b/lib/P3D2.lua
@@ -673,6 +673,29 @@ function P3D.P3DFile:Output()
 	Output(tostring(self))
 end
 
+local skip = {
+	["Chunks"] = true,
+	["Identifier"] = true,
+	["ValueStr"] = true,
+}
+local function P3DChunk_stateless_iter(self, k)
+	if not self.parentClass then
+		if k == nil then
+			return "ValueStr", self.ValueStr
+		else
+			return nil
+		end
+	end
+	local v
+	repeat
+		k, v = next(self, k)
+	until k == nil or not skip[k]
+	return k, v
+end
+local function P3DChunk_pairs(self)
+	return P3DChunk_stateless_iter, self, nil
+end
+
 local function P3DChunk_new(self, ...)
 	if self.Identifier and self.new then
 		return self:new(...)
@@ -690,6 +713,7 @@ local function P3DChunk_new(self, ...)
 		}
 		
 		self.__index = self
+		self.__pairs = P3DChunk_pairs
 		return setmetatable(Data, self)
 	end
 end
@@ -706,6 +730,7 @@ function P3D.P3DChunk:parse(Contents, Pos, DataLength, Identifier)
 	end
 	
 	self.__index = self
+	self.__pairs = P3DChunk_pairs
 	return setmetatable(Data, self)
 end
 

--- a/lib/P3D2.lua
+++ b/lib/P3D2.lua
@@ -226,6 +226,7 @@ local table_move = table.move
 local table_unpack = table.unpack
 
 local assert = assert
+local setmetatable = setmetatable
 local tostring = tostring
 local type = type
 

--- a/lib/P3D2.lua
+++ b/lib/P3D2.lua
@@ -713,12 +713,11 @@ local function P3DChunk_new(self, ...)
 		}
 		
 		self.__index = self
-		self.__pairs = P3DChunk_pairs
 		return setmetatable(Data, self)
 	end
 end
 
-P3D.P3DChunk = setmetatable({new = P3DChunk_new, AddChunk = AddChunk, SetChunk = SetChunk, RemoveChunk = RemoveChunk, GetChunks = GetChunks, GetChunk = GetChunk, GetChunksIndexed = GetChunksIndexed, GetChunkIndexed = GetChunkIndexed}, {__call = P3DChunk_new})
+P3D.P3DChunk = setmetatable({new = P3DChunk_new, __pairs = P3DChunk_pairs, AddChunk = AddChunk, SetChunk = SetChunk, RemoveChunk = RemoveChunk, GetChunks = GetChunks, GetChunk = GetChunk, GetChunksIndexed = GetChunksIndexed, GetChunkIndexed = GetChunkIndexed}, {__call = P3DChunk_new})
 function P3D.P3DChunk:parse(Contents, Pos, DataLength, Identifier)
 	local Data = {}
 	
@@ -730,7 +729,6 @@ function P3D.P3DChunk:parse(Contents, Pos, DataLength, Identifier)
 	end
 	
 	self.__index = self
-	self.__pairs = P3DChunk_pairs
 	return setmetatable(Data, self)
 end
 
@@ -746,7 +744,7 @@ end
 
 function P3D.P3DChunk:newChildClass(Identifier)
 	assert(type(Identifier) == "number", "Identifier must be a number")
-	local class = setmetatable({Identifier = Identifier, parentClass = self, AddChunk = AddChunk, SetChunk = SetChunk, RemoveChunk = RemoveChunk, GetChunks = GetChunks, GetChunk = GetChunk, GetChunksIndexed = GetChunksIndexed, GetChunkIndexed = GetChunkIndexed}, getmetatable(self))
+	local class = setmetatable({__pairs = P3DChunk_pairs, Identifier = Identifier, parentClass = self, AddChunk = AddChunk, SetChunk = SetChunk, RemoveChunk = RemoveChunk, GetChunks = GetChunks, GetChunk = GetChunk, GetChunksIndexed = GetChunksIndexed, GetChunkIndexed = GetChunkIndexed}, getmetatable(self))
 	P3D.ChunkClasses[Identifier] = class
 	return class
 end

--- a/lib/P3D2.lua
+++ b/lib/P3D2.lua
@@ -609,6 +609,7 @@ local function GetChunks(self, Identifier, Backwards)
 		local n = 1
 		return function()
 			while n <= chunkN do
+				assert(chunkN == #chunks, string_format("Chunk count changed from %d to %d. To add or remove chunks whilst iterating, you must iterate backwards", chunkN, #chunks))
 				local Chunk = chunks[n]
 				n = n + 1
 				if Identifier == nil or Chunk.Identifier == Identifier then
@@ -646,6 +647,7 @@ local function GetChunksIndexed(self, Identifier, Backwards)
 		local n = 1
 		return function()
 			while n <= chunkN do
+				assert(chunkN == #chunks, string_format("Chunk count changed from %d to %d. To add or remove chunks whilst iterating, you must iterate backwards", chunkN, #chunks))
 				local Chunk = chunks[n]
 				n = n + 1
 				if Identifier == nil or Chunk.Identifier == Identifier then

--- a/lib/P3D2.lua
+++ b/lib/P3D2.lua
@@ -707,7 +707,7 @@ local function Clone(self, seen)
 		res[Clone(k, s)] = Clone(v, s)
 	end
 	
-	return setmetatable(res, Clone(getmetatable(self), s))
+	return setmetatable(res, getmetatable(self))
 end
 
 P3D.P3DFile = setmetatable({load = LoadP3DFile, new = LoadP3DFile, AddChunk = AddChunk, SetChunk = SetChunk, RemoveChunk = RemoveChunk, GetChunks = GetChunks, GetChunk = GetChunk, GetChunksIndexed = GetChunksIndexed, GetChunkIndexed = GetChunkIndexed, Clone = Clone}, {__call = LoadP3DFile})

--- a/lib/P3DChunks/ATCP3DChunk.lua
+++ b/lib/P3DChunks/ATCP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Entries)

--- a/lib/P3DChunks/AnimCollP3DChunk.lua
+++ b/lib/P3DChunks/AnimCollP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, HasAlpha)

--- a/lib/P3DChunks/AnimDynaPhysP3DChunk.lua
+++ b/lib/P3DChunks/AnimDynaPhysP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, HasAlpha)

--- a/lib/P3DChunks/AnimDynaPhysWrapperP3DChunk.lua
+++ b/lib/P3DChunks/AnimDynaPhysWrapperP3DChunk.lua
@@ -11,10 +11,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, HasAlpha)

--- a/lib/P3DChunks/AnimObjWrapperP3DChunk.lua
+++ b/lib/P3DChunks/AnimObjWrapperP3DChunk.lua
@@ -11,10 +11,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, HasAlpha)

--- a/lib/P3DChunks/AnimP3DChunk.lua
+++ b/lib/P3DChunks/AnimP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, HasAlpha)

--- a/lib/P3DChunks/AnimatedObjectAnimationP3DChunk.lua
+++ b/lib/P3DChunks/AnimatedObjectAnimationP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Name, FrameRate, NumOldFrameControllers)

--- a/lib/P3DChunks/AnimatedObjectFactoryP3DChunk.lua
+++ b/lib/P3DChunks/AnimatedObjectFactoryP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Name, BaseAnimation, NumAnimations)

--- a/lib/P3DChunks/AnimatedObjectP3DChunk.lua
+++ b/lib/P3DChunks/AnimatedObjectP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Name, FactoryName, StartingAnimation)

--- a/lib/P3DChunks/AnimationChannelCountP3DChunk.lua
+++ b/lib/P3DChunks/AnimationChannelCountP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, ChannelChunkID, NumKeys)
@@ -42,7 +42,7 @@ function P3D.AnimationChannelCountP3DChunk:parse(Contents, Pos, DataLength)
 	local num, pos
 	chunk.Version, chunk.ChannelChunkID, num, pos = string_unpack("<III", chunk.ValueStr)
 	
-	chunk.NumKeys = table_pack(string_unpack("<" .. string_rep("H", num), chunk.ValueStr, pos))
+	chunk.NumKeys = {string_unpack("<" .. string_rep("H", num), chunk.ValueStr, pos)}
 	chunk.NumKeys[num + 1] = nil
 
 	return chunk

--- a/lib/P3DChunks/AnimationGroupListP3DChunk.lua
+++ b/lib/P3DChunks/AnimationGroupListP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version)

--- a/lib/P3DChunks/AnimationGroupP3DChunk.lua
+++ b/lib/P3DChunks/AnimationGroupP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Name, GroupId)

--- a/lib/P3DChunks/AnimationHeaderP3DChunk.lua
+++ b/lib/P3DChunks/AnimationHeaderP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, NumGroups)

--- a/lib/P3DChunks/AnimationP3DChunk.lua
+++ b/lib/P3DChunks/AnimationP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Name, AnimationType, NumFrames, FrameRate, Cyclic)

--- a/lib/P3DChunks/AnimationSizeP3DChunk.lua
+++ b/lib/P3DChunks/AnimationSizeP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, PC, PS2, XBOX, GC)

--- a/lib/P3DChunks/BooleanChannelP3DChunk.lua
+++ b/lib/P3DChunks/BooleanChannelP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Param, StartState, Values)
@@ -44,7 +44,7 @@ function P3D.BooleanChannelP3DChunk:parse(Contents, Pos, DataLength)
 	local numFrames, pos
 	chunk.Version, chunk.Param, chunk.StartState, numFrames, pos = string_unpack("<Ic4HI", chunk.ValueStr)
 	
-	chunk.Values = table_pack(string_unpack("<" .. string_rep("H", numFrames), chunk.ValueStr, pos))
+	chunk.Values = {string_unpack("<" .. string_rep("H", numFrames), chunk.ValueStr, pos)}
 	chunk.Values[numFrames + 1] = nil
 	
 	return chunk

--- a/lib/P3DChunks/BoundingBoxP3DChunk.lua
+++ b/lib/P3DChunks/BoundingBoxP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Low, High)

--- a/lib/P3DChunks/BoundingSphereP3DChunk.lua
+++ b/lib/P3DChunks/BoundingSphereP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Centre, Radius)

--- a/lib/P3DChunks/BreakableObjectP3DChunk.lua
+++ b/lib/P3DChunks/BreakableObjectP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Index, MaxInstances)

--- a/lib/P3DChunks/CameraP3DChunk.lua
+++ b/lib/P3DChunks/CameraP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, FOV, AspectRatio, NearClip, FarClip, Position, Look, Up)

--- a/lib/P3DChunks/ChannelInterpolationModeP3DChunk.lua
+++ b/lib/P3DChunks/ChannelInterpolationModeP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Interpolate)

--- a/lib/P3DChunks/CollisionAxisAlignedBoundingBoxP3DChunk.lua
+++ b/lib/P3DChunks/CollisionAxisAlignedBoundingBoxP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Nothing)

--- a/lib/P3DChunks/CollisionCylinderP3DChunk.lua
+++ b/lib/P3DChunks/CollisionCylinderP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, CylinderRadius, Length, FlatEnd)

--- a/lib/P3DChunks/CollisionEffectP3DChunk.lua
+++ b/lib/P3DChunks/CollisionEffectP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, ClassType, PhyPropID, SoundResourceDataName)

--- a/lib/P3DChunks/CollisionObjectAttributeP3DChunk.lua
+++ b/lib/P3DChunks/CollisionObjectAttributeP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, StaticAttribute, DefaultArea, CanRoll, CanSlide, CanSpin, CanBounce, ExtraAttribute1, ExtraAttribute2, ExtraAttribute3)

--- a/lib/P3DChunks/CollisionObjectP3DChunk.lua
+++ b/lib/P3DChunks/CollisionObjectP3DChunk.lua
@@ -20,7 +20,7 @@ local type = type
 
 local function new(self, Name, Version, MaterialName, NumSubObject)
 	assert(type(Name) == "string", "Arg #1 (Name) must be a string")
-	assert(type(FlatEnd) == "number", "Arg #2 (FlatEnd) must be a number")
+	assert(type(Version) == "number", "Arg #2 (Version) must be a number")
 	assert(type(MaterialName) == "string", "Arg #3 (MaterialName) must be a string")
 	assert(type(NumSubObject) == "number", "Arg #4 (NumSubObject) must be a number")
 	

--- a/lib/P3DChunks/CollisionObjectP3DChunk.lua
+++ b/lib/P3DChunks/CollisionObjectP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, MaterialName, NumSubObject)

--- a/lib/P3DChunks/CollisionOrientedBoundingBoxP3DChunk.lua
+++ b/lib/P3DChunks/CollisionOrientedBoundingBoxP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, HalfExtents)

--- a/lib/P3DChunks/CollisionSphereP3DChunk.lua
+++ b/lib/P3DChunks/CollisionSphereP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Radius)

--- a/lib/P3DChunks/CollisionVectorP3DChunk.lua
+++ b/lib/P3DChunks/CollisionVectorP3DChunk.lua
@@ -19,7 +19,7 @@ local assert = assert
 local type = type
 
 local function new(self, Vector)
-	assert(type(Vector) == "number", "Arg #1 (Vector) must be a number")
+	assert(type(Vector) == "table", "Arg #1 (Vector) must be a table")
 	
 	local Data = {
 		Chunks = {},

--- a/lib/P3DChunks/CollisionVectorP3DChunk.lua
+++ b/lib/P3DChunks/CollisionVectorP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Vector)

--- a/lib/P3DChunks/CollisionVolumeOwnerNameP3DChunk.lua
+++ b/lib/P3DChunks/CollisionVolumeOwnerNameP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name)

--- a/lib/P3DChunks/CollisionVolumeOwnerP3DChunk.lua
+++ b/lib/P3DChunks/CollisionVolumeOwnerP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self)

--- a/lib/P3DChunks/CollisionVolumeP3DChunk.lua
+++ b/lib/P3DChunks/CollisionVolumeP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, ObjectReferenceIndex, OwnerIndex)

--- a/lib/P3DChunks/CollisionWallP3DChunk.lua
+++ b/lib/P3DChunks/CollisionWallP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self)

--- a/lib/P3DChunks/ColourChannelP3DChunk.lua
+++ b/lib/P3DChunks/ColourChannelP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Param, Frames, Values)
@@ -45,7 +45,7 @@ function P3D.ColourChannelP3DChunk:parse(Contents, Pos, DataLength)
 	local numFrames, pos
 	chunk.Version, chunk.Param, numFrames, pos = string_unpack("<Ic4I", chunk.ValueStr)
 	
-	chunk.Frames = table_pack(string_unpack("<" .. string_rep("H", numFrames), chunk.ValueStr, pos))
+	chunk.Frames = {string_unpack("<" .. string_rep("H", numFrames), chunk.ValueStr, pos)}
 	pos = chunk.Frames[numFrames + 1]
 	chunk.Frames[numFrames + 1] = nil
 	

--- a/lib/P3DChunks/ColourListP3DChunk.lua
+++ b/lib/P3DChunks/ColourListP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Colours)

--- a/lib/P3DChunks/CompositeDrawableEffectListP3DChunk.lua
+++ b/lib/P3DChunks/CompositeDrawableEffectListP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self)

--- a/lib/P3DChunks/CompositeDrawableEffectP3DChunk.lua
+++ b/lib/P3DChunks/CompositeDrawableEffectP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, IsTranslucent, SkeletonJointID)

--- a/lib/P3DChunks/CompositeDrawableP3DChunk.lua
+++ b/lib/P3DChunks/CompositeDrawableP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, SkeletonName)

--- a/lib/P3DChunks/CompositeDrawablePropListP3DChunk.lua
+++ b/lib/P3DChunks/CompositeDrawablePropListP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self)

--- a/lib/P3DChunks/CompositeDrawablePropP3DChunk.lua
+++ b/lib/P3DChunks/CompositeDrawablePropP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, IsTranslucent, SkeletonJointID)

--- a/lib/P3DChunks/CompositeDrawableSkinListP3DChunk.lua
+++ b/lib/P3DChunks/CompositeDrawableSkinListP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self)

--- a/lib/P3DChunks/CompositeDrawableSkinP3DChunk.lua
+++ b/lib/P3DChunks/CompositeDrawableSkinP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, IsTranslucent)

--- a/lib/P3DChunks/CompositeDrawableSortOrderP3DChunk.lua
+++ b/lib/P3DChunks/CompositeDrawableSortOrderP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, SortOrder)

--- a/lib/P3DChunks/CompressedQuaternionChannelP3DChunk.lua
+++ b/lib/P3DChunks/CompressedQuaternionChannelP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Param, Frames, Values)
@@ -45,7 +45,7 @@ function P3D.CompressedQuaternionChannelP3DChunk:parse(Contents, Pos, DataLength
 	local numFrames, pos
 	chunk.Version, chunk.Param, numFrames, pos = string_unpack("<Ic4I", chunk.ValueStr)
 	
-	chunk.Frames = table_pack(string_unpack("<" .. string_rep("H", numFrames), chunk.ValueStr, pos))
+	chunk.Frames = {string_unpack("<" .. string_rep("H", numFrames), chunk.ValueStr, pos)}
 	pos = chunk.Frames[numFrames + 1]
 	chunk.Frames[numFrames + 1] = nil
 	

--- a/lib/P3DChunks/DynaPhysP3DChunk.lua
+++ b/lib/P3DChunks/DynaPhysP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, HasAlpha)

--- a/lib/P3DChunks/EntityChannelP3DChunk.lua
+++ b/lib/P3DChunks/EntityChannelP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Param, Frames, Values)
@@ -45,11 +45,11 @@ function P3D.EntityChannelP3DChunk:parse(Contents, Pos, DataLength)
 	local numFrames, pos
 	chunk.Version, chunk.Param, numFrames, pos = string_unpack("<Ic4I", chunk.ValueStr)
 	
-	chunk.Frames = table_pack(string_unpack("<" .. string_rep("H", numFrames), chunk.ValueStr, pos))
+	chunk.Frames = {string_unpack("<" .. string_rep("H", numFrames), chunk.ValueStr, pos)}
 	pos = chunk.Frames[numFrames + 1]
 	chunk.Frames[numFrames + 1] = nil
 	
-	chunk.Values = table_pack(string_unpack("<" .. string_rep("s1", numFrames), chunk.ValueStr, pos))
+	chunk.Values = {string_unpack("<" .. string_rep("s1", numFrames), chunk.ValueStr, pos)}
 	chunk.Values[numFrames + 1] = nil
 	for i=1,numFrames do
 		chunk.Values[i] = P3D.CleanP3DString(chunk.Values[i])

--- a/lib/P3DChunks/ExportInfoNamedIntegerP3DChunk.lua
+++ b/lib/P3DChunks/ExportInfoNamedIntegerP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Value)

--- a/lib/P3DChunks/ExportInfoNamedStringP3DChunk.lua
+++ b/lib/P3DChunks/ExportInfoNamedStringP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Value)

--- a/lib/P3DChunks/ExportInfoP3DChunk.lua
+++ b/lib/P3DChunks/ExportInfoP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name)

--- a/lib/P3DChunks/ExpressionGroupP3DChunk.lua
+++ b/lib/P3DChunks/ExpressionGroupP3DChunk.lua
@@ -11,10 +11,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Name, TargetName, Stages)
@@ -45,7 +45,7 @@ function P3D.ExpressionGroupP3DChunk:parse(Contents, Pos, DataLength)
 	chunk.Name = P3D.CleanP3DString(chunk.Name)
 	chunk.TargetName = P3D.CleanP3DString(chunk.TargetName)
 	
-	chunk.Stages = table_pack(string_unpack("<" .. string_rep("I", num), chunk.ValueStr, pos))
+	chunk.Stages = {string_unpack("<" .. string_rep("I", num), chunk.ValueStr, pos)}
 	chunk.Stages[num + 1] = nil
 	
 	return chunk

--- a/lib/P3DChunks/ExpressionMixerP3DChunk.lua
+++ b/lib/P3DChunks/ExpressionMixerP3DChunk.lua
@@ -11,10 +11,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Name, Type, TargetName, ExpressionGroupName)

--- a/lib/P3DChunks/ExpressionP3DChunk.lua
+++ b/lib/P3DChunks/ExpressionP3DChunk.lua
@@ -11,10 +11,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Name, Keys, Indices)
@@ -45,11 +45,11 @@ function P3D.ExpressionP3DChunk:parse(Contents, Pos, DataLength)
 	chunk.Version, chunk.Name, num, pos = string_unpack("<Is1I", chunk.ValueStr)
 	chunk.Name = P3D.CleanP3DString(chunk.Name)
 	
-	chunk.Keys = table_pack(string_unpack("<" .. string_rep("f", num), chunk.ValueStr, pos))
+	chunk.Keys = {string_unpack("<" .. string_rep("f", num), chunk.ValueStr, pos)}
 	pos = chunk.Keys[num + 1]
 	chunk.Keys[num + 1] = nil
 	
-	chunk.Indices = table_pack(string_unpack("<" .. string_rep("I", num), chunk.ValueStr, pos))
+	chunk.Indices = {string_unpack("<" .. string_rep("I", num), chunk.ValueStr, pos)}
 	chunk.Indices[num + 1] = nil
 	
 	return chunk

--- a/lib/P3DChunks/Fence2P3DChunk.lua
+++ b/lib/P3DChunks/Fence2P3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Start, End, Normal)

--- a/lib/P3DChunks/FenceP3DChunk.lua
+++ b/lib/P3DChunks/FenceP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self)

--- a/lib/P3DChunks/Float1ChannelP3DChunk.lua
+++ b/lib/P3DChunks/Float1ChannelP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Param, Frames, Values)
@@ -45,11 +45,11 @@ function P3D.Float1ChannelP3DChunk:parse(Contents, Pos, DataLength)
 	local numFrames, pos
 	chunk.Version, chunk.Param, numFrames, pos = string_unpack("<Ic4I", chunk.ValueStr)
 	
-	chunk.Frames = table_pack(string_unpack("<" .. string_rep("H", numFrames), chunk.ValueStr, pos))
+	chunk.Frames = {string_unpack("<" .. string_rep("H", numFrames), chunk.ValueStr, pos)}
 	pos = chunk.Frames[numFrames + 1]
 	chunk.Frames[numFrames + 1] = nil
 	
-	chunk.Values = table_pack(string_unpack("<" .. string_rep("f", numFrames), chunk.ValueStr, pos))
+	chunk.Values = {string_unpack("<" .. string_rep("f", numFrames), chunk.ValueStr, pos)}
 	chunk.Values[numFrames + 1] = nil
 	
 	return chunk

--- a/lib/P3DChunks/Float2ChannelP3DChunk.lua
+++ b/lib/P3DChunks/Float2ChannelP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Param, Frames, Values)
@@ -45,7 +45,7 @@ function P3D.EntityChannelP3DChunk:parse(Contents, Pos, DataLength)
 	local numFrames, pos
 	chunk.Version, chunk.Param, numFrames, pos = string_unpack("<Ic4I", chunk.ValueStr)
 	
-	chunk.Frames = table_pack(string_unpack("<" .. string_rep("H", numFrames), chunk.ValueStr, pos))
+	chunk.Frames = {string_unpack("<" .. string_rep("H", numFrames), chunk.ValueStr, pos)}
 	pos = chunk.Frames[numFrames + 1]
 	chunk.Frames[numFrames + 1] = nil
 	

--- a/lib/P3DChunks/Float2ChannelP3DChunk.lua
+++ b/lib/P3DChunks/Float2ChannelP3DChunk.lua
@@ -37,9 +37,9 @@ local function new(self, Version, Param, Frames, Values)
 	return setmetatable(Data, self)
 end
 
-P3D.EntityChannelP3DChunk = P3D.P3DChunk:newChildClass(P3D.Identifiers.Float_2_Channel)
-P3D.EntityChannelP3DChunk.new = new
-function P3D.EntityChannelP3DChunk:parse(Contents, Pos, DataLength)
+P3D.Float2ChannelP3DChunk = P3D.P3DChunk:newChildClass(P3D.Identifiers.Float_2_Channel)
+P3D.Float2ChannelP3DChunk.new = new
+function P3D.Float2ChannelP3DChunk:parse(Contents, Pos, DataLength)
 	local chunk = self.parentClass.parse(self, Contents, Pos, DataLength, self.Identifier)
 	
 	local numFrames, pos
@@ -59,7 +59,7 @@ function P3D.EntityChannelP3DChunk:parse(Contents, Pos, DataLength)
 	return chunk
 end
 
-function P3D.EntityChannelP3DChunk:__tostring()
+function P3D.Float2ChannelP3DChunk:__tostring()
 	local chunks = {}
 	for i=1,#self.Chunks do
 		chunks[i] = tostring(self.Chunks[i])

--- a/lib/P3DChunks/FollowCameraDataP3DChunk.lua
+++ b/lib/P3DChunks/FollowCameraDataP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Index, Rotation, Elevation, Magnitude, TargetOffset)

--- a/lib/P3DChunks/FrameControllerP3DChunk.lua
+++ b/lib/P3DChunks/FrameControllerP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Name, Type, CycleMode, NumCycles, InfiniteCycle, HierarchyName, AnimationName)

--- a/lib/P3DChunks/FrontendGroupP3DChunk.lua
+++ b/lib/P3DChunks/FrontendGroupP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, Alpha)

--- a/lib/P3DChunks/FrontendImageResourceP3DChunk.lua
+++ b/lib/P3DChunks/FrontendImageResourceP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, Filename)

--- a/lib/P3DChunks/FrontendLanguageP3DChunk.lua
+++ b/lib/P3DChunks/FrontendLanguageP3DChunk.lua
@@ -12,13 +12,13 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local utf8_char = utf8.char
 local utf8_codes = utf8.codes
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Language, Modulo, Entries)
@@ -81,11 +81,11 @@ function P3D.FrontendLanguageP3DChunk:parse(Contents, Pos, DataLength)
 	chunk.Name, chunk.Language, numEntries, chunk.Modulo, bufferSize, pos = string_unpack("<s1c1III", chunk.ValueStr)
 	chunk.Name = P3D.CleanP3DString(chunk.Name)
 	
-	chunk.Hashes = table_pack(string_unpack("<" .. string_rep("I", numEntries), chunk.ValueStr, pos))
+	chunk.Hashes = {string_unpack("<" .. string_rep("I", numEntries), chunk.ValueStr, pos)}
 	pos = chunk.Hashes[numEntries + 1]
 	chunk.Hashes[numEntries + 1] = nil
 	
-	chunk.Offsets = table_pack(string_unpack("<" .. string_rep("I", numEntries), chunk.ValueStr, pos))
+	chunk.Offsets = {string_unpack("<" .. string_rep("I", numEntries), chunk.ValueStr, pos)}
 	pos = chunk.Offsets[numEntries + 1]
 	chunk.Offsets[numEntries + 1] = nil
 	

--- a/lib/P3DChunks/FrontendLanguageP3DChunk.lua
+++ b/lib/P3DChunks/FrontendLanguageP3DChunk.lua
@@ -193,7 +193,7 @@ function P3D.FrontendLanguageP3DChunk:SetValue(Name, Value)
 	self.Buffer = self.Buffer:sub(1, offset) .. Value .. self.Buffer:sub(offset + startLen + 1)
 	
 	local diff = #Value - startLen
-	for i=idx + 1,#self.Offsets do
+	for i=index + 1,#self.Offsets do
 		self.Offsets[i] = self.Offsets[i] + diff
 	end
 end

--- a/lib/P3DChunks/FrontendLanguageP3DChunk.lua
+++ b/lib/P3DChunks/FrontendLanguageP3DChunk.lua
@@ -45,13 +45,12 @@ local function new(self, Name, Language, Modulo, Entries)
 		Hashes[i] = hash
 		
 		local ucs2 = {}
-		local n = 0
+		local n = 1
 		for p, c in utf8_codes(value) do
 			if c == 0 then break end
-			n = n + 1
 			ucs2[n] = c
+			n = n + 1
 		end
-		n = n + 1
 		ucs2[n] = 0
 		value = string_pack("<" .. string_rep("H", n), table_unpack(ucs2))
 		Buffer[i] = value
@@ -146,13 +145,12 @@ function P3D.FrontendLanguageP3DChunk:AddValue(Name, Value)
 	assert(type(Value) == "string", "Arg #2 (Value) must be a string")
 	
 	local ucs2 = {}
-	local n = 0
+	local n = 1
 	for p,c in utf8_codes(Value) do
 		if c == 0 then break end
-		n = n + 1
 		ucs2[n] = c
+		n = n + 1
 	end
-	n = n + 1
 	ucs2[n] = 0
 	
 	Value = string_pack("<" .. string_rep("H", n), table_unpack(ucs2))
@@ -181,13 +179,12 @@ function P3D.FrontendLanguageP3DChunk:SetValue(Name, Value)
 	local startLen = (self.Offsets[index + 1] or #self.Buffer) - offset
 	
 	local ucs2 = {}
-	local n = 0
+	local n = 1
 	for p,c in utf8_codes(Value) do
 		if c == 0 then break end
-		n = n + 1
 		ucs2[n] = c
+		n = n + 1
 	end
-	n = n + 1
 	ucs2[n] = 0
 	
 	Value = string_pack("<" .. string_rep("H", n), table_unpack(ucs2))

--- a/lib/P3DChunks/FrontendLanguageP3DChunk.lua
+++ b/lib/P3DChunks/FrontendLanguageP3DChunk.lua
@@ -95,6 +95,7 @@ end
 
 function P3D.FrontendLanguageP3DChunk:GetNameHash(Name, Modulo)
 	assert(type(Name) == "string", "Arg #1 (Name) must be a string")
+	assert(Modulo == nil or type(Modulo) == "number", "Arg #2 (Modulo) must be a number")
 	
 	Modulo = Modulo or self.Modulo
 	local Hash = 0

--- a/lib/P3DChunks/FrontendLayerP3DChunk.lua
+++ b/lib/P3DChunks/FrontendLayerP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, Visible, Editable, Alpha)

--- a/lib/P3DChunks/FrontendMultiSpriteP3DChunk.lua
+++ b/lib/P3DChunks/FrontendMultiSpriteP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, Position, Dimension, Justification, Colour, Translucency, RotationValue, ImageNames)
@@ -66,7 +66,7 @@ function P3D.FrontendMultiSpriteP3DChunk:parse(Contents, Pos, DataLength)
 	chunk.Name, chunk.Version, chunk.Position.X, chunk.Position.Y, chunk.Dimension.X, chunk.Dimension.Y, chunk.Justification.X, chunk.Justification.Y, chunk.Colour.B, chunk.Colour.G, chunk.Colour.R, chunk.Colour.A, chunk.Translucency, chunk.RotationValue, num, pos = string_unpack("<s1IiiIIIIBBBBIfI", chunk.ValueStr)
 	chunk.Name = P3D.CleanP3DString(chunk.Name)
 	
-	chunk.ImageNames = table_pack(string_unpack("<" .. string_rep("s1", num), chunk.ValueStr, pos))
+	chunk.ImageNames = {string_unpack("<" .. string_rep("s1", num), chunk.ValueStr, pos)}
 	chunk.ImageNames[num + 1] = nil
 	for i=1,num do
 		chunk.ImageNames[i] = P3D.CleanP3DString(chunk.ImageNames[i])

--- a/lib/P3DChunks/FrontendMultiTextP3DChunk.lua
+++ b/lib/P3DChunks/FrontendMultiTextP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, Position, Dimension, Justification, Colour, Translucency, RotationValue, TextStyleName, ShadowEnabled, ShadowColour, ShadowOffset, CurrentText)

--- a/lib/P3DChunks/FrontendPageP3DChunk.lua
+++ b/lib/P3DChunks/FrontendPageP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, Resolution)

--- a/lib/P3DChunks/FrontendPolygonP3DChunk.lua
+++ b/lib/P3DChunks/FrontendPolygonP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, Translucency, Points, Colours)

--- a/lib/P3DChunks/FrontendProjectP3DChunk.lua
+++ b/lib/P3DChunks/FrontendProjectP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, Resolution, Platform, PagePath, ResourcePath, ScreenPath)

--- a/lib/P3DChunks/FrontendPure3DObjectP3DChunk.lua
+++ b/lib/P3DChunks/FrontendPure3DObjectP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, Position, Dimension, Justification, Colour, Translucency, RotationValue, Pure3DFilename)

--- a/lib/P3DChunks/FrontendPure3DResourceP3DChunk.lua
+++ b/lib/P3DChunks/FrontendPure3DResourceP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, Filename, InventoryName, CameraName, AnimationName)

--- a/lib/P3DChunks/FrontendScreenP3DChunk.lua
+++ b/lib/P3DChunks/FrontendScreenP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, PageNames)
@@ -43,7 +43,7 @@ function P3D.FrontendScreenP3DChunk:parse(Contents, Pos, DataLength)
 	chunk.Name, chunk.Version, num, pos = string_unpack("<s1II", chunk.ValueStr)
 	chunk.Name = P3D.CleanP3DString(chunk.Name)
 	
-	chunk.PageNames = table_pack(string_unpack("<" .. string_rep("s1", num), chunk.ValueStr, pos))
+	chunk.PageNames = {string_unpack("<" .. string_rep("s1", num), chunk.ValueStr, pos)}
 	chunk.PageNames[num + 1] = nil
 	
 	return chunk

--- a/lib/P3DChunks/FrontendStringHardCodedP3DChunk.lua
+++ b/lib/P3DChunks/FrontendStringHardCodedP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, String)

--- a/lib/P3DChunks/FrontendStringTextBibleP3DChunk.lua
+++ b/lib/P3DChunks/FrontendStringTextBibleP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, BibleName, StringID)

--- a/lib/P3DChunks/FrontendTextBibleP3DChunk.lua
+++ b/lib/P3DChunks/FrontendTextBibleP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name)

--- a/lib/P3DChunks/FrontendTextBibleResourceP3DChunk.lua
+++ b/lib/P3DChunks/FrontendTextBibleResourceP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, Filename, InventoryName)

--- a/lib/P3DChunks/FrontendTextStyleResourceP3DChunk.lua
+++ b/lib/P3DChunks/FrontendTextStyleResourceP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, Filename, InventoryName)

--- a/lib/P3DChunks/GameAttrColourParameterP3DChunk.lua
+++ b/lib/P3DChunks/GameAttrColourParameterP3DChunk.lua
@@ -11,10 +11,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, ParameterName, Value)

--- a/lib/P3DChunks/GameAttrFloatParameterP3DChunk.lua
+++ b/lib/P3DChunks/GameAttrFloatParameterP3DChunk.lua
@@ -11,10 +11,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, ParameterName, Value)

--- a/lib/P3DChunks/GameAttrIntegerParameterP3DChunk.lua
+++ b/lib/P3DChunks/GameAttrIntegerParameterP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, ParameterName, Value)

--- a/lib/P3DChunks/GameAttrMatrixParameterP3DChunk.lua
+++ b/lib/P3DChunks/GameAttrMatrixParameterP3DChunk.lua
@@ -11,10 +11,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, ParameterName, Value)

--- a/lib/P3DChunks/GameAttrP3DChunk.lua
+++ b/lib/P3DChunks/GameAttrP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version)

--- a/lib/P3DChunks/GameAttrVectorParameterP3DChunk.lua
+++ b/lib/P3DChunks/GameAttrVectorParameterP3DChunk.lua
@@ -11,10 +11,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, ParameterName, Value)

--- a/lib/P3DChunks/HistoryP3DChunk.lua
+++ b/lib/P3DChunks/HistoryP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, History)
@@ -36,7 +36,7 @@ function P3D.HistoryP3DChunk:parse(Contents, Pos, DataLength)
 	local chunk = self.parentClass.parse(self, Contents, Pos, DataLength, self.Identifier)
 	
 	local num, pos = string_unpack("<H", chunk.ValueStr)
-	chunk.History = table_pack(string_unpack("<" .. string_rep("s1", num), chunk.ValueStr, pos))
+	chunk.History = {string_unpack("<" .. string_rep("s1", num), chunk.ValueStr, pos)}
 	chunk.History[num + 1] = nil
 	for i=1,num do
 		chunk.History[i] = P3D.CleanP3DString(chunk.History[i])

--- a/lib/P3DChunks/ImageDataP3DChunk.lua
+++ b/lib/P3DChunks/ImageDataP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, ImageData)

--- a/lib/P3DChunks/ImageP3DChunk.lua
+++ b/lib/P3DChunks/ImageP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, Width, Height, Bpp, Palettized, HasAlpha, Format)

--- a/lib/P3DChunks/IndexListP3DChunk.lua
+++ b/lib/P3DChunks/IndexListP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Indices)
@@ -37,7 +37,7 @@ function P3D.IndexListP3DChunk:parse(Contents, Pos, DataLength)
 	
 	local num, pos = string_unpack("<I", chunk.ValueStr)
 	
-	chunk.Indices = table_pack(string_unpack("<" .. string_rep("I", num), chunk.ValueStr, pos))
+	chunk.Indices = {string_unpack("<" .. string_rep("I", num), chunk.ValueStr, pos)}
 	chunk.Indices[num + 1] = nil
 	
 	return chunk

--- a/lib/P3DChunks/InstParticleSystemP3DChunk.lua
+++ b/lib/P3DChunks/InstParticleSystemP3DChunk.lua
@@ -11,10 +11,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, ParticleType, MaxInstances)

--- a/lib/P3DChunks/InstStatEntityP3DChunk.lua
+++ b/lib/P3DChunks/InstStatEntityP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, HasAlpha)

--- a/lib/P3DChunks/InstStatPhysP3DChunk.lua
+++ b/lib/P3DChunks/InstStatPhysP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, HasAlpha)

--- a/lib/P3DChunks/InstanceListP3DChunk.lua
+++ b/lib/P3DChunks/InstanceListP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name)

--- a/lib/P3DChunks/IntegerChannelP3DChunk.lua
+++ b/lib/P3DChunks/IntegerChannelP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Param, Frames, Values)
@@ -45,11 +45,11 @@ function P3D.IntegerChannelP3DChunk:parse(Contents, Pos, DataLength)
 	local numFrames, pos
 	chunk.Version, chunk.Param, numFrames, pos = string_unpack("<Ic4I", chunk.ValueStr)
 	
-	chunk.Frames = table_pack(string_unpack("<" .. string_rep("H", numFrames), chunk.ValueStr, pos))
+	chunk.Frames = {string_unpack("<" .. string_rep("H", numFrames), chunk.ValueStr, pos)}
 	pos = chunk.Frames[numFrames + 1]
 	chunk.Frames[numFrames + 1] = nil
 	
-	chunk.Values = table_pack(string_unpack("<" .. string_rep("I", numFrames), chunk.ValueStr, pos))
+	chunk.Values = {string_unpack("<" .. string_rep("I", numFrames), chunk.ValueStr, pos)}
 	chunk.Values[numFrames + 1] = nil
 	
 	return chunk

--- a/lib/P3DChunks/IntersectMesh2P3DChunk.lua
+++ b/lib/P3DChunks/IntersectMesh2P3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, SurfaceType)

--- a/lib/P3DChunks/IntersectMeshP3DChunk.lua
+++ b/lib/P3DChunks/IntersectMeshP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name)

--- a/lib/P3DChunks/IntersectP3DChunk.lua
+++ b/lib/P3DChunks/IntersectP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Indices, Positions, Normals)
@@ -43,7 +43,7 @@ function P3D.IntersectP3DChunk:parse(Contents, Pos, DataLength)
 	
 	local num, pos = string_unpack("<I", chunk.ValueStr)
 	
-	chunk.Indices = table_pack(string_unpack("<" .. string_rep("I", num), chunk.ValueStr, pos))
+	chunk.Indices = {string_unpack("<" .. string_rep("I", num), chunk.ValueStr, pos)}
 	pos = chunk.Indices[num + 1]
 	chunk.Indices[num + 1] = nil
 	

--- a/lib/P3DChunks/IntersectionP3DChunk.lua
+++ b/lib/P3DChunks/IntersectionP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Position, Radius, TrafficBehaviour)

--- a/lib/P3DChunks/LensFlareP3DChunk.lua
+++ b/lib/P3DChunks/LensFlareP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version)

--- a/lib/P3DChunks/LightDirectionP3DChunk.lua
+++ b/lib/P3DChunks/LightDirectionP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Direction)

--- a/lib/P3DChunks/LightGroupP3DChunk.lua
+++ b/lib/P3DChunks/LightGroupP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Lights)
@@ -41,7 +41,7 @@ function P3D.LightGroupP3DChunk:parse(Contents, Pos, DataLength)
 	chunk.Name, num, pos = string_unpack("<s1I", chunk.ValueStr)
 	chunk.Name = P3D.CleanP3DString(chunk.Name)
 	
-	chunk.Lights = table_pack(string_unpack("<" .. string_rep("s1", num), chunk.ValueStr, pos))
+	chunk.Lights = {string_unpack("<" .. string_rep("s1", num), chunk.ValueStr, pos)}
 	chunk.Lights[num + 1] = nil
 	for i=1,num do
 		chunk.Lights[i] = P3D.CleanP3DString(chunk.Lights[i])

--- a/lib/P3DChunks/LightIlluminationTypeP3DChunk.lua
+++ b/lib/P3DChunks/LightIlluminationTypeP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, IlluminationType)

--- a/lib/P3DChunks/LightP3DChunk.lua
+++ b/lib/P3DChunks/LightP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, Type, Colour, Constant, Linear, Squard, Enabled)

--- a/lib/P3DChunks/LightPositionP3DChunk.lua
+++ b/lib/P3DChunks/LightPositionP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Position)

--- a/lib/P3DChunks/LightShadowP3DChunk.lua
+++ b/lib/P3DChunks/LightShadowP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Shadow)

--- a/lib/P3DChunks/Locator3P3DChunk.lua
+++ b/lib/P3DChunks/Locator3P3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, Position)

--- a/lib/P3DChunks/LocatorMatrixP3DChunk.lua
+++ b/lib/P3DChunks/LocatorMatrixP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Matrix)

--- a/lib/P3DChunks/LocatorP3DChunk.lua
+++ b/lib/P3DChunks/LocatorP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Position, Type, ...)

--- a/lib/P3DChunks/LocatorP3DChunk.lua
+++ b/lib/P3DChunks/LocatorP3DChunk.lua
@@ -68,7 +68,7 @@ local function new(self, Name, Position, Type, ...)
 		local Occlusions = args[1]
 		assert(Occlusions == nil or type(Occlusions) == "number", "Arg #4 (Occlusions) must be a number")
 		
-		Data.Occlusions = Occlusinos
+		Data.Occlusions = Occlusions
 	elseif Type == 7 then -- Interior Entrance
 		local InteriorName = args[1]
 		local Right = args[2]

--- a/lib/P3DChunks/MatrixListP3DChunk.lua
+++ b/lib/P3DChunks/MatrixListP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Matrices)

--- a/lib/P3DChunks/MatrixPaletteP3DChunk.lua
+++ b/lib/P3DChunks/MatrixPaletteP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Matrices)

--- a/lib/P3DChunks/MeshP3DChunk.lua
+++ b/lib/P3DChunks/MeshP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version)

--- a/lib/P3DChunks/MeshP3DChunk.lua
+++ b/lib/P3DChunks/MeshP3DChunk.lua
@@ -20,7 +20,7 @@ local type = type
 
 local function new(self, Name, Version)
 	assert(type(Name) == "string", "Arg #1 (Name) must be a string")
-	assert(type(Version) == "string", "Arg #2 (Version) must be a number")
+	assert(type(Version) == "number", "Arg #2 (Version) must be a number")
 	
 	local Data = {
 		Chunks = {},

--- a/lib/P3DChunks/MultiController2P3DChunk.lua
+++ b/lib/P3DChunks/MultiController2P3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Name, CycleMode, NumCycles, InfiniteCycle, NumFrames, FrameRate, NumTracks)

--- a/lib/P3DChunks/MultiControllerP3DChunk.lua
+++ b/lib/P3DChunks/MultiControllerP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, Length, Framerate)

--- a/lib/P3DChunks/MultiControllerTrackP3DChunk.lua
+++ b/lib/P3DChunks/MultiControllerTrackP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Name, Type)

--- a/lib/P3DChunks/MultiControllerTracksP3DChunk.lua
+++ b/lib/P3DChunks/MultiControllerTracksP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Tracks)

--- a/lib/P3DChunks/NormalListP3DChunk.lua
+++ b/lib/P3DChunks/NormalListP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Normals)

--- a/lib/P3DChunks/OldBaseEmitterDisplayInfoP3DChunk.lua
+++ b/lib/P3DChunks/OldBaseEmitterDisplayInfoP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Rotation, CutOffMode, UVOffsetRange, SourceRange, EdgeRange)

--- a/lib/P3DChunks/OldBaseEmitterP3DChunk.lua
+++ b/lib/P3DChunks/OldBaseEmitterP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Name, ParticleType, GeneratorType, ZTest, ZWrite, Fog, MaxParticles, InfiniteLife, RotationalCohesion, TranslationalCohesion)

--- a/lib/P3DChunks/OldBaseEmitterPerspectiveInfoP3DChunk.lua
+++ b/lib/P3DChunks/OldBaseEmitterPerspectiveInfoP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Perspective)

--- a/lib/P3DChunks/OldBillboardQuadGroupP3DChunk.lua
+++ b/lib/P3DChunks/OldBillboardQuadGroupP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Name, Shader, ZTest, ZWrite, Fog)

--- a/lib/P3DChunks/OldBillboardQuadP3DChunk.lua
+++ b/lib/P3DChunks/OldBillboardQuadP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Name, BillboardMode, Translation, Colour, Uv0, Uv1, Uv2, Uv3, Width, Height, Distance, UVOffset)

--- a/lib/P3DChunks/OldColourOffsetListP3DChunk.lua
+++ b/lib/P3DChunks/OldColourOffsetListP3DChunk.lua
@@ -11,10 +11,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Offsets)

--- a/lib/P3DChunks/OldEmitterAnimationP3DChunk.lua
+++ b/lib/P3DChunks/OldEmitterAnimationP3DChunk.lua
@@ -11,10 +11,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version)

--- a/lib/P3DChunks/OldExpressionOffsetsP3DChunk.lua
+++ b/lib/P3DChunks/OldExpressionOffsetsP3DChunk.lua
@@ -11,10 +11,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, NumPrimGroups, NumOffsetLists, PrimGroupIndices)
@@ -42,7 +42,7 @@ function P3D.OldExpressionOffsetsP3DChunk:parse(Contents, Pos, DataLength)
 	local pos
 	chunk.NumPrimGroups, chunk.NumOffsetLists, pos = string_unpack("<II", chunk.ValueStr)
 	
-	chunk.PrimGroupIndices = table_pack(string_unpack("<" .. string_rep("I", chunk.NumPrimGroups), chunk.ValueStr, pos))
+	chunk.PrimGroupIndices = {string_unpack("<" .. string_rep("I", chunk.NumPrimGroups), chunk.ValueStr, pos)}
 	chunk.PrimGroupIndices[chunk.NumPrimGroups + 1] = nil
 	
 	return chunk

--- a/lib/P3DChunks/OldFrameControllerP3DChunk.lua
+++ b/lib/P3DChunks/OldFrameControllerP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Name, Type, FrameOffset, HierarchyName, AnimationName)

--- a/lib/P3DChunks/OldGeneratorAnimationP3DChunk.lua
+++ b/lib/P3DChunks/OldGeneratorAnimationP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version)

--- a/lib/P3DChunks/OldIndexOffsetListP3DChunk.lua
+++ b/lib/P3DChunks/OldIndexOffsetListP3DChunk.lua
@@ -55,5 +55,5 @@ function P3D.OldIndexOffsetListP3DChunk:__tostring()
 	local offsetsN = #self.Offsets
 	
 	local headerLen = 12 + 4 + 4 + offsetsN * 4
-	return string_pack("<IIIII" .. string_rep("I", offsetsN), self.Identifier, headerLen, headerLen + #chunkData, self.Version, offsetsN, table_unpack(self.Offsets)) .. offsetsData .. chunkData
+	return string_pack("<IIIII" .. string_rep("I", offsetsN), self.Identifier, headerLen, headerLen + #chunkData, self.Version, offsetsN, table_unpack(self.Offsets)) .. chunkData
 end

--- a/lib/P3DChunks/OldIndexOffsetListP3DChunk.lua
+++ b/lib/P3DChunks/OldIndexOffsetListP3DChunk.lua
@@ -11,10 +11,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Offsets)
@@ -39,7 +39,7 @@ function P3D.OldIndexOffsetListP3DChunk:parse(Contents, Pos, DataLength)
 	local num, pos
 	chunk.Version, num, pos = string_unpack("<II", chunk.ValueStr)
 	
-	chunk.Offsets = table_pack(string_unpack("<" .. string_rep("I", num), chunk.ValueStr, pos))
+	chunk.Offsets = {string_unpack("<" .. string_rep("I", num), chunk.ValueStr, pos)}
 	chunk.Offsets[num + 1] = nil
 	
 	return chunk

--- a/lib/P3DChunks/OldOffsetListP3DChunk.lua
+++ b/lib/P3DChunks/OldOffsetListP3DChunk.lua
@@ -11,10 +11,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, KeyIndex, Offsets, PrimGroupIndex)

--- a/lib/P3DChunks/OldParticleAnimationP3DChunk.lua
+++ b/lib/P3DChunks/OldParticleAnimationP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version)

--- a/lib/P3DChunks/OldParticleInstancingInfoP3DChunk.lua
+++ b/lib/P3DChunks/OldParticleInstancingInfoP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, MaxInstances)

--- a/lib/P3DChunks/OldPrimitiveGroupP3DChunk.lua
+++ b/lib/P3DChunks/OldPrimitiveGroupP3DChunk.lua
@@ -88,6 +88,16 @@ function P3D.OldPrimitiveGroupP3DChunk:parse(Contents, Pos, DataLength)
 	return chunk
 end
 
+local function UVTypeMap = {
+	P3D.OldPrimitiveGroupP3DChunk.VertexTypes.UVs,
+	P3D.OldPrimitiveGroupP3DChunk.VertexTypes.UVs2,
+	P3D.OldPrimitiveGroupP3DChunk.VertexTypes.UVs3,
+	P3D.OldPrimitiveGroupP3DChunk.VertexTypes.UVs4,
+	P3D.OldPrimitiveGroupP3DChunk.VertexTypes.UVs5,
+	P3D.OldPrimitiveGroupP3DChunk.VertexTypes.UVs6,
+	P3D.OldPrimitiveGroupP3DChunk.VertexTypes.UVs7,
+	P3D.OldPrimitiveGroupP3DChunk.VertexTypes.UVs8,
+}
 function P3D.OldPrimitiveGroupP3DChunk:GetVertexType()
 	local vertexType = 0
 	
@@ -109,25 +119,8 @@ function P3D.OldPrimitiveGroupP3DChunk:GetVertexType()
 		end
 	end
 	if uvN > 0 then
-		if uvN == 1 then
-			vertexType = vertexType | P3D.OldPrimitiveGroupP3DChunk.VertexTypes.UVs
-		elseif uvN == 2 then
-			vertexType = vertexType | P3D.OldPrimitiveGroupP3DChunk.VertexTypes.UVs2
-		elseif uvN == 3 then
-			vertexType = vertexType | P3D.OldPrimitiveGroupP3DChunk.VertexTypes.UVs3
-		elseif uvN == 4 then
-			vertexType = vertexType | P3D.OldPrimitiveGroupP3DChunk.VertexTypes.UVs4
-		elseif uvN == 5 then
-			vertexType = vertexType | P3D.OldPrimitiveGroupP3DChunk.VertexTypes.UVs5
-		elseif uvN == 6 then
-			vertexType = vertexType | P3D.OldPrimitiveGroupP3DChunk.VertexTypes.UVs6
-		elseif uvN == 7 then
-			vertexType = vertexType | P3D.OldPrimitiveGroupP3DChunk.VertexTypes.UVs7
-		elseif uvN == 8 then
-			vertexType = vertexType | P3D.OldPrimitiveGroupP3DChunk.VertexTypes.UVs8
-		else
-			error("Too manu UVs")
-		end
+		assert(uvN <= 8, "Old Primitive Groups can only have a maximum of 8 UV Lists")
+		vertexType = vertexType | UVTypeMap[uvN]
 	end
 	
 	return vertexType

--- a/lib/P3DChunks/OldPrimitiveGroupP3DChunk.lua
+++ b/lib/P3DChunks/OldPrimitiveGroupP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, ShaderName, PrimitiveType, NumVertices, NumIndices, NumMatrices)

--- a/lib/P3DChunks/OldPrimitiveGroupP3DChunk.lua
+++ b/lib/P3DChunks/OldPrimitiveGroupP3DChunk.lua
@@ -28,12 +28,12 @@ local function new(self, Version, ShaderName, PrimitiveType, NumVertices, NumInd
 
 	local Data = {
 		Chunks = {},
-		Version = {},
-		ShaderName = {},
-		PrimitiveType = {},
-		NumVertices = {},
-		NumIndices = {},
-		NumMatrices = {},
+		Version = Version,
+		ShaderName = ShaderName,
+		PrimitiveType = PrimitiveType,
+		NumVertices = NumVertices,
+		NumIndices = NumIndices,
+		NumMatrices = NumMatrices,
 	}
 	
 	self.__index = self
@@ -88,7 +88,16 @@ function P3D.OldPrimitiveGroupP3DChunk:parse(Contents, Pos, DataLength)
 	return chunk
 end
 
-local function UVTypeMap = {
+local VertexTypeMap = {
+	[P3D.Identifiers.Packed_Normal_List] = P3D.OldPrimitiveGroupP3DChunk.VertexTypes.Normals,
+	[P3D.Identifiers.Normal_List] = P3D.OldPrimitiveGroupP3DChunk.VertexTypes.Normals,
+	[P3D.Identifiers.Colour_List] = P3D.OldPrimitiveGroupP3DChunk.VertexTypes.Colours,
+	[P3D.Identifiers.Matrix_List] = P3D.OldPrimitiveGroupP3DChunk.VertexTypes.Matrices,
+	[P3D.Identifiers.Matrix_Palette] = P3D.OldPrimitiveGroupP3DChunk.VertexTypes.Matrices,
+	[P3D.Identifiers.Weight_List] = P3D.OldPrimitiveGroupP3DChunk.VertexTypes.Weights,
+	[P3D.Identifiers.Position_List] = P3D.OldPrimitiveGroupP3DChunk.VertexTypes.Position,
+}
+local UVTypeMap = {
 	P3D.OldPrimitiveGroupP3DChunk.VertexTypes.UVs,
 	P3D.OldPrimitiveGroupP3DChunk.VertexTypes.UVs2,
 	P3D.OldPrimitiveGroupP3DChunk.VertexTypes.UVs3,
@@ -106,16 +115,11 @@ function P3D.OldPrimitiveGroupP3DChunk:GetVertexType()
 		local identifier = self.Chunks[i].Identifier
 		if identifier == P3D.Identifiers.UV_List then
 			uvN = uvN + 1
-		elseif identifier == P3D.Identifiers.Packed_Normal_List or identifier == P3D.Identifiers.Normal_List then
-			vertexType = vertexType | P3D.OldPrimitiveGroupP3DChunk.VertexTypes.Normals
-		elseif identifier == P3D.Identifiers.Colour_List then
-			vertexType = vertexType | P3D.OldPrimitiveGroupP3DChunk.VertexTypes.Colours
-		elseif identifier == P3D.Identifiers.Matrix_List or identifier == P3D.Identifiers.Matrix_Palette then
-			vertexType = vertexType | P3D.OldPrimitiveGroupP3DChunk.VertexTypes.Matrices
-		elseif identifier == P3D.Identifiers.Weight_List then
-			vertexType = vertexType | P3D.OldPrimitiveGroupP3DChunk.VertexTypes.Weights
-		elseif identifier == P3D.Identifiers.Position_List then
-			vertexType = vertexType | P3D.OldPrimitiveGroupP3DChunk.VertexTypes.Position
+		else
+			local chunkVertexType = VertexTypeMap[identifier]
+			if chunkVertexType then
+				vertexType = vertexType | chunkVertexType
+			end
 		end
 	end
 	if uvN > 0 then

--- a/lib/P3DChunks/OldScenegraphBranchP3DChunk.lua
+++ b/lib/P3DChunks/OldScenegraphBranchP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name)

--- a/lib/P3DChunks/OldScenegraphDrawableP3DChunk.lua
+++ b/lib/P3DChunks/OldScenegraphDrawableP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, DrawableName, IsTranslucent)

--- a/lib/P3DChunks/OldScenegraphLightGroupP3DChunk.lua
+++ b/lib/P3DChunks/OldScenegraphLightGroupP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, LightGroupName)

--- a/lib/P3DChunks/OldScenegraphRootP3DChunk.lua
+++ b/lib/P3DChunks/OldScenegraphRootP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self)

--- a/lib/P3DChunks/OldScenegraphSortOrderP3DChunk.lua
+++ b/lib/P3DChunks/OldScenegraphSortOrderP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, SortOrder)

--- a/lib/P3DChunks/OldScenegraphTransformP3DChunk.lua
+++ b/lib/P3DChunks/OldScenegraphTransformP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Transform)

--- a/lib/P3DChunks/OldScenegraphVisibilityP3DChunk.lua
+++ b/lib/P3DChunks/OldScenegraphVisibilityP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, IsVisible)

--- a/lib/P3DChunks/OldSpriteEmitterP3DChunk.lua
+++ b/lib/P3DChunks/OldSpriteEmitterP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Name, ShaderName, AngleMode, Angle, TextureAnimMode, NumTextureFrames, TextureFrameRate)

--- a/lib/P3DChunks/OldVector2OffsetListP3DChunk.lua
+++ b/lib/P3DChunks/OldVector2OffsetListP3DChunk.lua
@@ -11,10 +11,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Offsets, Param)

--- a/lib/P3DChunks/OldVectorOffsetListP3DChunk.lua
+++ b/lib/P3DChunks/OldVectorOffsetListP3DChunk.lua
@@ -11,10 +11,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Offsets, Param)

--- a/lib/P3DChunks/OldVertexAnimKeyFrameP3DChunk.lua
+++ b/lib/P3DChunks/OldVertexAnimKeyFrameP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Name)

--- a/lib/P3DChunks/PackedNormalListP3DChunk.lua
+++ b/lib/P3DChunks/PackedNormalListP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Normals)
@@ -37,7 +37,7 @@ function P3D.PackedNormalListP3DChunk:parse(Contents, Pos, DataLength)
 	
 	local num, pos = string_unpack("<I", chunk.ValueStr)
 	
-	chunk.Normals = table_pack(string_unpack("<" .. string_rep("B", num), chunk.ValueStr, pos))
+	chunk.Normals = {string_unpack("<" .. string_rep("B", num), chunk.ValueStr, pos)}
 	chunk.Normals[num + 1] = nil
 	
 	return chunk

--- a/lib/P3DChunks/ParticleSystem2P3DChunk.lua
+++ b/lib/P3DChunks/ParticleSystem2P3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Name, FactoryName)

--- a/lib/P3DChunks/ParticleSystemFactoryP3DChunk.lua
+++ b/lib/P3DChunks/ParticleSystemFactoryP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Name, FrameRate, NumAnimFrames, NumOLFrames, CycleAnim, EnableSorting)

--- a/lib/P3DChunks/PathP3DChunk.lua
+++ b/lib/P3DChunks/PathP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Positions)

--- a/lib/P3DChunks/PhysicsInertiaMatrixP3DChunk.lua
+++ b/lib/P3DChunks/PhysicsInertiaMatrixP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Matrix)

--- a/lib/P3DChunks/PhysicsJointP3DChunk.lua
+++ b/lib/P3DChunks/PhysicsJointP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Index, Volume, Stiffness, MaxAngle, MinAngle, DOF)

--- a/lib/P3DChunks/PhysicsObjectP3DChunk.lua
+++ b/lib/P3DChunks/PhysicsObjectP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, MaterialName, NumJoints, Volume, RestingSensitivity)

--- a/lib/P3DChunks/PhysicsVectorP3DChunk.lua
+++ b/lib/P3DChunks/PhysicsVectorP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Vector)

--- a/lib/P3DChunks/PositionListP3DChunk.lua
+++ b/lib/P3DChunks/PositionListP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Positions)

--- a/lib/P3DChunks/QuaternionChannelP3DChunk.lua
+++ b/lib/P3DChunks/QuaternionChannelP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Param, Frames, Values)
@@ -45,7 +45,7 @@ function P3D.QuaternionChannelP3DChunk:parse(Contents, Pos, DataLength)
 	local numFrames, pos
 	chunk.Version, chunk.Param, numFrames, pos = string_unpack("<Ic4I", chunk.ValueStr)
 	
-	chunk.Frames = table_pack(string_unpack("<" .. string_rep("H", numFrames), chunk.ValueStr, pos))
+	chunk.Frames = {string_unpack("<" .. string_rep("H", numFrames), chunk.ValueStr, pos)}
 	pos = chunk.Frames[numFrames + 1]
 	chunk.Frames[numFrames + 1] = nil
 	

--- a/lib/P3DChunks/RailCamP3DChunk.lua
+++ b/lib/P3DChunks/RailCamP3DChunk.lua
@@ -11,10 +11,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Behaviour, MinRadius, MaxRadius, TrackRail, TrackDist, ReverseSense, FOV, TargetOffset, AxisPlay, PositionLag, TargetLag)

--- a/lib/P3DChunks/RenderStatusP3DChunk.lua
+++ b/lib/P3DChunks/RenderStatusP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, CastShadow)

--- a/lib/P3DChunks/RoadDataSegmentP3DChunk.lua
+++ b/lib/P3DChunks/RoadDataSegmentP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Type, Lanes, HasShoulder, Position, Position2, Position3)

--- a/lib/P3DChunks/RoadP3DChunk.lua
+++ b/lib/P3DChunks/RoadP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Type, StartIntersection, EndIntersection, MaximumCars, Speed, Intelligence, Shortcut)

--- a/lib/P3DChunks/RoadSegmentP3DChunk.lua
+++ b/lib/P3DChunks/RoadSegmentP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, RoadDataSegment, Transform, Scale)

--- a/lib/P3DChunks/ScenegraphP3DChunk.lua
+++ b/lib/P3DChunks/ScenegraphP3DChunk.lua
@@ -11,10 +11,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version)

--- a/lib/P3DChunks/SetP3DChunk.lua
+++ b/lib/P3DChunks/SetP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version)

--- a/lib/P3DChunks/ShaderColourParamP3DChunk.lua
+++ b/lib/P3DChunks/ShaderColourParamP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Param, Value)

--- a/lib/P3DChunks/ShaderFloatParamP3DChunk.lua
+++ b/lib/P3DChunks/ShaderFloatParamP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Param, Value)

--- a/lib/P3DChunks/ShaderIntegerParameterP3DChunk.lua
+++ b/lib/P3DChunks/ShaderIntegerParameterP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Param, Value)

--- a/lib/P3DChunks/ShaderP3DChunk.lua
+++ b/lib/P3DChunks/ShaderP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, PddiShaderName, HasTranslucency, VertexNeeds, VertexMask)

--- a/lib/P3DChunks/ShaderTextureParameterP3DChunk.lua
+++ b/lib/P3DChunks/ShaderTextureParameterP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Param, Value)

--- a/lib/P3DChunks/SkeletonJointBonePreserveP3DChunk.lua
+++ b/lib/P3DChunks/SkeletonJointBonePreserveP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, PreserveBoneLengths)

--- a/lib/P3DChunks/SkeletonJointMirrorMapP3DChunk.lua
+++ b/lib/P3DChunks/SkeletonJointMirrorMapP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, MappedJointIndex, XAxisMap, YAxisMap, ZAxisMap)

--- a/lib/P3DChunks/SkeletonJointP3DChunk.lua
+++ b/lib/P3DChunks/SkeletonJointP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Parent, DOF, FreeAxis, PrimaryAxis, SecondaryAxis, TwistAxis, RestPose)

--- a/lib/P3DChunks/SkeletonP3DChunk.lua
+++ b/lib/P3DChunks/SkeletonP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version)

--- a/lib/P3DChunks/SkinP3DChunk.lua
+++ b/lib/P3DChunks/SkinP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, SkeletonName)

--- a/lib/P3DChunks/SplineP3DChunk.lua
+++ b/lib/P3DChunks/SplineP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Positions)

--- a/lib/P3DChunks/SpriteP3DChunk.lua
+++ b/lib/P3DChunks/SpriteP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, NativeX, NativeY, Shader, ImageWidth, ImageHeight, BlitBorder)

--- a/lib/P3DChunks/StatePropCallbackDataP3DChunk.lua
+++ b/lib/P3DChunks/StatePropCallbackDataP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, EventEnum, OnFrame)

--- a/lib/P3DChunks/StatePropDataV1P3DChunk.lua
+++ b/lib/P3DChunks/StatePropDataV1P3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Name, ObjectFactoryName)

--- a/lib/P3DChunks/StatePropEventDataP3DChunk.lua
+++ b/lib/P3DChunks/StatePropEventDataP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, State, EventEnum)

--- a/lib/P3DChunks/StatePropFrameControllerDataP3DChunk.lua
+++ b/lib/P3DChunks/StatePropFrameControllerDataP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Cyclic, NumberOfCycles, HoldFrame, MinFrame, MaxFrame, RelativeSpeed)

--- a/lib/P3DChunks/StatePropStateDataV1P3DChunk.lua
+++ b/lib/P3DChunks/StatePropStateDataV1P3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, AutoTransition, OutState, NumDrawables, NumFrameControllers, NumEvents, NumCallbacks, OutFrame)

--- a/lib/P3DChunks/StatePropVisibilitiesDataP3DChunk.lua
+++ b/lib/P3DChunks/StatePropVisibilitiesDataP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Visible)

--- a/lib/P3DChunks/StaticEntityP3DChunk.lua
+++ b/lib/P3DChunks/StaticEntityP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, HasAlpha)

--- a/lib/P3DChunks/StaticPhysP3DChunk.lua
+++ b/lib/P3DChunks/StaticPhysP3DChunk.lua
@@ -11,10 +11,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version)

--- a/lib/P3DChunks/SurfaceTypeListP3DChunk.lua
+++ b/lib/P3DChunks/SurfaceTypeListP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Types)
@@ -40,7 +40,7 @@ function P3D.SurfaceTypeListP3DChunk:parse(Contents, Pos, DataLength)
 	local num, pos
 	chunk.Version, num, pos = string_unpack("<II", chunk.ValueStr)
 	
-	chunk.Types = table_pack(string_unpack("<" .. string_rep("B", num), chunk.ValueStr, pos))
+	chunk.Types = {string_unpack("<" .. string_rep("B", num), chunk.ValueStr, pos)}
 	chunk.Types[num + 1] = nil
 	
 	return chunk

--- a/lib/P3DChunks/TextureAnimationP3DChunk.lua
+++ b/lib/P3DChunks/TextureAnimationP3DChunk.lua
@@ -11,10 +11,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, MaterialName, NumFrames, FrameRate, Cyclic)

--- a/lib/P3DChunks/TextureFontP3DChunk.lua
+++ b/lib/P3DChunks/TextureFontP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Name, Shader, FontSize, FontWidth, FontHeight, FontBaseLine)

--- a/lib/P3DChunks/TextureGlyphListP3DChunk.lua
+++ b/lib/P3DChunks/TextureGlyphListP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Glyphs)

--- a/lib/P3DChunks/TextureP3DChunk.lua
+++ b/lib/P3DChunks/TextureP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, Width, Height, Bpp, AlphaDepth, NumMipMaps, TextureType, Usage, Priority)

--- a/lib/P3DChunks/TreeNode2P3DChunk.lua
+++ b/lib/P3DChunks/TreeNode2P3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, SplitAxis, SplitPosition, StaticEntityLimit, StaticPhysEntityLimit, IntersectEntityLimit, DynaPhysEntityLimit, FenceEntityLimit, RoadSegmentEntityLimit, PathSegmentEntityLimit, AnimEntityLimit)

--- a/lib/P3DChunks/TreeNodeP3DChunk.lua
+++ b/lib/P3DChunks/TreeNodeP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, NumChildren, ParentOffset)

--- a/lib/P3DChunks/TreeP3DChunk.lua
+++ b/lib/P3DChunks/TreeP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Minimum, Maximum)

--- a/lib/P3DChunks/TriggerVolumeP3DChunk.lua
+++ b/lib/P3DChunks/TriggerVolumeP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, IsRect, HalfExtents, Matrix)

--- a/lib/P3DChunks/UVListP3DChunk.lua
+++ b/lib/P3DChunks/UVListP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Channel, UVs)

--- a/lib/P3DChunks/Vector1DOFChannelP3DChunk.lua
+++ b/lib/P3DChunks/Vector1DOFChannelP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Param, Mapping, Constants, Frames, Values)
@@ -50,11 +50,11 @@ function P3D.Vector1DOFChannelP3DChunk:parse(Contents, Pos, DataLength)
 	chunk.Constants = {}
 	chunk.Version, chunk.Param, chunk.Mapping, chunk.Constants.X, chunk.Constants.Y, chunk.Constants.Z, num, pos = string_unpack("<Ic4HfffI", chunk.ValueStr)
 	
-	chunk.Frames = table_pack(string_unpack("<" .. string_rep("H", num), chunk.ValueStr, pos))
+	chunk.Frames = {string_unpack("<" .. string_rep("H", num), chunk.ValueStr, pos)}
 	pos = chunk.Frames[num + 1]
 	chunk.Frames[num + 1] = nil
 	
-	chunk.Values = table_pack(string_unpack("<" .. string_rep("f", num), chunk.ValueStr, pos))
+	chunk.Values = {string_unpack("<" .. string_rep("f", num), chunk.ValueStr, pos)}
 	chunk.Values[num + 1] = nil
 	
 	return chunk

--- a/lib/P3DChunks/Vector2DOFChannelP3DChunk.lua
+++ b/lib/P3DChunks/Vector2DOFChannelP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Param, Mapping, Constants, Frames, Values)
@@ -50,7 +50,7 @@ function P3D.Vector2DOFChannelP3DChunk:parse(Contents, Pos, DataLength)
 	chunk.Constants = {}
 	chunk.Version, chunk.Param, chunk.Mapping, chunk.Constants.X, chunk.Constants.Y, chunk.Constants.Z, num, pos = string_unpack("<Ic4HfffI", chunk.ValueStr)
 	
-	chunk.Frames = table_pack(string_unpack("<" .. string_rep("H", num), chunk.ValueStr, pos))
+	chunk.Frames = {string_unpack("<" .. string_rep("H", num), chunk.ValueStr, pos)}
 	pos = chunk.Frames[num + 1]
 	chunk.Frames[num + 1] = nil
 	

--- a/lib/P3DChunks/Vector3DOFChannelP3DChunk.lua
+++ b/lib/P3DChunks/Vector3DOFChannelP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Version, Param, Frames, Values)
@@ -45,7 +45,7 @@ function P3D.Vector3DOFChannelP3DChunk:parse(Contents, Pos, DataLength)
 	local num, pos
 	chunk.Version, chunk.Param, num, pos = string_unpack("<Ic4I", chunk.ValueStr)
 	
-	chunk.Frames = table_pack(string_unpack("<" .. string_rep("H", num), chunk.ValueStr, pos))
+	chunk.Frames = {string_unpack("<" .. string_rep("H", num), chunk.ValueStr, pos)}
 	pos = chunk.Frames[num + 1]
 	chunk.Frames[num + 1] = nil
 	

--- a/lib/P3DChunks/VertexShaderP3DChunk.lua
+++ b/lib/P3DChunks/VertexShaderP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, VertexShaderName)

--- a/lib/P3DChunks/VolumeImageP3DChunk.lua
+++ b/lib/P3DChunks/VolumeImageP3DChunk.lua
@@ -11,10 +11,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version, Width, Height, Depth, Bpp, Palettized, HasAlpha, Format)

--- a/lib/P3DChunks/WalkerCameraDataP3DChunk.lua
+++ b/lib/P3DChunks/WalkerCameraDataP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Index, MinMagnitude, MaxMagnitude, Elevation, TargetOffset)

--- a/lib/P3DChunks/WeightListP3DChunk.lua
+++ b/lib/P3DChunks/WeightListP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Weights)

--- a/lib/P3DChunks/WorldSphereP3DChunk.lua
+++ b/lib/P3DChunks/WorldSphereP3DChunk.lua
@@ -12,10 +12,10 @@ local string_rep = string.rep
 local string_unpack = string.unpack
 
 local table_concat = table.concat
-local table_pack = table.pack
 local table_unpack = table.unpack
 
 local assert = assert
+local tostring = tostring
 local type = type
 
 local function new(self, Name, Version)


### PR DESCRIPTION
* Updating example mod `Meta.ini`
* Fixed the constructors of `CollisionObjectP3DChunk` and `CollisionVectorP3DChunk`
* Fixing typo in `LocatorP3DChunk` constructor
* Added `__pairs` metamethod to `P3DChunk` class to only output properties if a known chunk, and `ValueStr` if unknown
* Improved `__pairs` metamethod implementation for `P3DChunk` class
* Improved `P3D.DecompressBlock`
* Added `Path` to invalid P3D file error
* Replaced slow `table_pack` with faster `{}`
* Added local reference to `tostring` for faster building
* Minor optimisation to `FrontendLanguage` class
* Added a missing assert in `FrontendLanguageP3DChunk:GetNameHash`
* Added `Clone` method to `P3DFile` and `P3DChunk`
* Remove redundant comment
* Fixed a bug in `:GetChunks` and `:GetChunksIndexed` where it looked at `chunksN` instead of `chunkN`
* Fixed `:Clone()` incorrectly cloning the metatable too. Should use the standard metatable of the chunk type.
* Added `:Match(Filters)`
* Added `:Find(Filters, Backwards)`
* Added `:FindFirst(Filters, Backwards)`
* Added `:Replace(NewChunk)`
* Fixed a bug in `Mesh` constructor
* Improved `OldPrimitiveGroupP3DChunk` UV List handling
* Fixed a bug in `OldPrimitiveGroupP3DChunk` constructor
* Improved `OldPrimitiveGroupP3DChunk` `GetVertexType()`
* Fixed a bug in `FrontendLanguageP3DChunk:SetValue`
* Fixed a bug in `OldIndexOffsetListP3DChunk:__tostring()`
* Started implementation of Vector maths
* Fixed a typo in `Float2ChannelP3DChunk` (Thanks @mazexz7 for pointing it out)
* Fixed a bug when adding a chunk by index to the end of the chunk list